### PR TITLE
Add BoardService simple test

### DIFF
--- a/src/test/java/com/crud/BoardServiceTests.java
+++ b/src/test/java/com/crud/BoardServiceTests.java
@@ -1,0 +1,21 @@
+package com.crud;
+
+import com.crud.board.service.BoardService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class BoardServiceTests {
+
+    @Autowired
+    BoardService boardService;
+
+    @Test
+    void countBoardListReturnsNonNegative() {
+        int count = boardService.countBoardList();
+        assertThat(count).isGreaterThanOrEqualTo(0);
+    }
+}


### PR DESCRIPTION
## Summary
- add a BoardService test under `src/test/java/com/crud`
- test ensures `countBoardList()` returns a non-negative value

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684e82f597f8832c9abd5a567b099384